### PR TITLE
Handle env API credentials and normalize Anthropic endpoint

### DIFF
--- a/src/components/ChatContainer.jsx
+++ b/src/components/ChatContainer.jsx
@@ -23,6 +23,13 @@ function ChatContainer() {
   const messagesEndRef = useRef(null)
   const session = getCurrentSession()
   const provider = getCurrentProvider()
+  const mergedApiKey = aiService.getApiKey(currentProvider)
+  const mergedEndpoint = aiService.getApiEndpoint(currentProvider)
+  const providerConfig = {
+    ...(provider || {}),
+    apiKey: mergedApiKey,
+    baseURL: mergedEndpoint
+  }
 
   // 自动滚动到底部
   const scrollToBottom = () => {
@@ -37,7 +44,7 @@ function ChatContainer() {
   const handleSend = async (input) => {
     const { text, images } = input
 
-    if (!provider?.apiKey && currentProvider !== 'custom') {
+    if (!mergedApiKey && currentProvider !== 'custom') {
       alert(`请先在设置中配置 ${provider?.name} 的 API Key`)
       setSettingsOpen(true)
       return
@@ -83,7 +90,7 @@ function ChatContainer() {
           currentProvider,
           messages,
           model,
-          provider,
+          providerConfig,
           {
             temperature: settings.temperature,
             maxTokens: settings.maxTokens
@@ -106,7 +113,7 @@ function ChatContainer() {
           currentProvider,
           messages,
           model,
-          provider,
+          providerConfig,
           {
             temperature: settings.temperature,
             maxTokens: settings.maxTokens
@@ -144,7 +151,7 @@ function ChatContainer() {
               <div className="feature-item">⚡ 实时流式输出</div>
               <div className="feature-item">📝 Markdown 和代码高亮</div>
             </div>
-            {!provider?.apiKey && currentProvider !== 'custom' && (
+            {!mergedApiKey && currentProvider !== 'custom' && (
               <button className="setup-btn" onClick={() => setSettingsOpen(true)}>
                 <Settings size={18} />
                 开始配置

--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -35,9 +35,12 @@ function SettingsPanel({ isOpen, onClose }) {
   const handleTestConnection = async (providerKey) => {
     setTesting(true)
 
+    const mergedApiKey = aiService.getApiKey(providerKey)
+    const mergedEndpoint = aiService.getApiEndpoint(providerKey)
+
     const config = {
-      apiKey: providers[providerKey].apiKey,
-      endpoint: providers[providerKey].baseURL,
+      apiKey: mergedApiKey,
+      endpoint: mergedEndpoint,
       apiType: 'openai' // custom API 默认使用 openai 类型
     }
 
@@ -62,6 +65,7 @@ function SettingsPanel({ isOpen, onClose }) {
   if (!isOpen) return null
 
   const provider = providers[currentProvider]
+  const effectiveApiKey = aiService.getApiKey(currentProvider)
 
   const toggleApiKeyVisibility = (providerKey) => {
     setShowApiKey(prev => ({ ...prev, [providerKey]: !prev[providerKey] }))
@@ -155,7 +159,7 @@ function SettingsPanel({ isOpen, onClose }) {
                   <button
                     className="test-btn"
                     onClick={() => handleTestConnection(currentProvider)}
-                    disabled={!provider.apiKey || testing}
+                    disabled={(currentProvider !== 'custom' && !effectiveApiKey) || testing}
                   >
                     {testing ? '测试中...' : '测试'}
                   </button>

--- a/src/store/useStore.js
+++ b/src/store/useStore.js
@@ -19,7 +19,7 @@ export const useStore = create(
         anthropic: {
           name: 'Anthropic Claude',
           apiKey: '',
-          baseURL: 'https://api.anthropic.com/v1',
+          baseURL: 'https://api.anthropic.com',
           models: ['claude-3-5-sonnet-20241022', 'claude-3-opus-20240229', 'claude-3-sonnet-20240229', 'claude-3-haiku-20240307'],
           defaultModel: 'claude-3-5-sonnet-20241022',
           supportsVision: true,


### PR DESCRIPTION
## Summary
- merge environment/stored API keys and endpoints when initializing AI clients and testing connections
- validate merged API keys in chat sends and settings test button so env-only configuration works
- normalize Anthropic base URLs and update defaults to avoid duplicated /v1 paths in requests

## Testing
- Not run (per instructions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692fe0ca5960832bb8e8039bdd875515)