### PR TITLE
Render provider select options dynamically and add test

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.71.0",
@@ -26,6 +27,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.2.0",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
@@ -33,6 +36,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
-    "vite": "^7.2.6"
+    "vite": "^7.2.6",
+    "vitest": "^2.1.8"
   }
 }

--- a/src/components/RightPanel.jsx
+++ b/src/components/RightPanel.jsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { useStore } from '../store/useStore'
 import { X, Settings as SettingsIcon } from 'lucide-react'
 import './RightPanel.css'
@@ -16,6 +17,11 @@ function RightPanel({ isOpen, onClose }) {
   } = useStore()
 
   const provider = providers[currentProvider]
+
+  const providerEntries = useMemo(
+    () => Object.entries(providers || {}),
+    [providers]
+  )
 
   // 获取合并后的模型列表（默认 + 动态 + 自定义）
   const getMergedModels = (providerKey) => {
@@ -63,10 +69,11 @@ function RightPanel({ isOpen, onClose }) {
           value={currentProvider}
           onChange={(e) => setCurrentProvider(e.target.value)}
         >
-          <option value="openai">OpenAI</option>
-          <option value="anthropic">Anthropic Claude</option>
-          <option value="google">Google Gemini</option>
-          <option value="custom">自定义 API</option>
+          {providerEntries.map(([key, config]) => (
+            <option key={key} value={key}>
+              {config.name}
+            </option>
+          ))}
         </select>
 
         <h4 className="section-title">模型</h4>

--- a/src/components/RightPanel.test.jsx
+++ b/src/components/RightPanel.test.jsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import RightPanel from './RightPanel'
+import { useStore } from '../store/useStore'
+import '@testing-library/jest-dom/vitest'
+
+const baseProviders = useStore.getState().providers
+const baseProvider = useStore.getState().currentProvider
+
+const resetStore = () => {
+  useStore.setState({
+    providers: baseProviders,
+    currentProvider: baseProvider
+  })
+}
+
+describe('RightPanel', () => {
+  beforeEach(() => {
+    resetStore()
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    cleanup()
+    resetStore()
+  })
+
+  it('renders provider options from the store configuration', () => {
+    useStore.setState((state) => ({
+      providers: {
+        ...state.providers,
+        testProvider: {
+          name: 'Test Provider',
+          apiKey: '',
+          baseURL: 'https://api.test.com',
+          models: ['test-model'],
+          defaultModel: 'test-model',
+          supportsVision: false,
+          supportsStreaming: false
+        }
+      },
+      currentProvider: 'testProvider'
+    }))
+
+    render(<RightPanel isOpen onClose={() => {}} />)
+
+    const providerSelect = screen.getAllByRole('combobox')[0]
+    expect(providerSelect).toHaveValue('testProvider')
+    expect(screen.getByRole('option', { name: 'Test Provider' })).toBeInTheDocument()
+  })
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -32,5 +32,11 @@ export default defineConfig({
   // 优化依赖预构建
   optimizeDeps: {
     include: ['react', 'react-dom', 'zustand', 'lucide-react']
+  },
+
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: []
   }
 })


### PR DESCRIPTION
## Summary
- render the provider dropdown options by iterating over the provider configuration
- configure vitest and testing dependencies for component checks
- add a RightPanel test to ensure providers added to the store appear in the selector

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692ff26abe78832b8e25831257469cf5)