### PR TITLE
Refactor composer controls into sticky bar

### DIFF
--- a/src/components/ChatContainer.css
+++ b/src/components/ChatContainer.css
@@ -5,8 +5,9 @@
   height: 100%;
   background: radial-gradient(circle at 20% 20%, rgba(168, 199, 250, 0.14), transparent 35%), radial-gradient(circle at 80% 0%, rgba(255, 255, 255, 0.06), transparent 40%), var(--bg-primary);
   padding: var(--spacing-5) var(--spacing-6);
-  overflow: hidden;
+  overflow: visible;
   flex: 1;
+  gap: var(--spacing-4);
 }
 
 .canvas-header {
@@ -14,8 +15,7 @@
   justify-content: space-between;
   align-items: flex-start;
   gap: var(--spacing-4);
-  padding: var(--spacing-4) var(--spacing-5);
-  margin-bottom: var(--spacing-4);
+  padding: var(--spacing-3) var(--spacing-4);
   border: 1px solid var(--border-primary);
   border-radius: var(--radius-2xl);
   background: var(--bg-secondary);
@@ -45,7 +45,7 @@
   display: flex;
   gap: var(--spacing-2);
   flex-wrap: wrap;
-  justify-content: flex-end;
+  justify-content: flex-start;
 }
 
 .mode-switch {
@@ -73,6 +73,30 @@
   background: var(--accent-light);
   color: var(--accent-primary);
   font-weight: 700;
+}
+
+/* 控制与输入组合区域 */
+.composer-sticky {
+  position: sticky;
+  bottom: var(--spacing-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+  padding: var(--spacing-3) var(--spacing-4);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-2xl);
+  background: rgba(16, 19, 26, 0.9);
+  backdrop-filter: blur(8px);
+  box-shadow: var(--shadow-lg);
+  z-index: 5;
+}
+
+.composer-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-3);
+  flex-wrap: wrap;
 }
 
 .canvas-chip {
@@ -337,7 +361,7 @@
 /* 输入区域 */
 .input-area-new {
   background: transparent;
-  padding: var(--spacing-4) var(--spacing-1) var(--spacing-1);
+  padding: 0;
 }
 
 /* 响应式设计 */
@@ -351,7 +375,6 @@
     align-items: stretch;
     gap: var(--spacing-3);
     padding: var(--spacing-3);
-    margin-bottom: var(--spacing-3);
   }
 
   .canvas-titles {
@@ -376,13 +399,30 @@
     font-size: var(--font-xs);
   }
 
+  .composer-sticky {
+    bottom: var(--spacing-3);
+    padding: var(--spacing-3);
+    gap: var(--spacing-2);
+  }
+
+  .composer-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
   .mode-switch {
     order: -1;
+    width: 100%;
+    justify-content: space-between;
   }
 
   .mode-pill {
     padding: var(--spacing-1) var(--spacing-2);
     font-size: var(--font-xs);
+  }
+
+  .canvas-chips {
+    width: 100%;
   }
 
   .messages-area-new {
@@ -426,7 +466,7 @@
   }
 
   .input-area-new {
-    padding: var(--spacing-3) 0 0;
+    padding: 0;
   }
 }
 
@@ -440,6 +480,17 @@
     border-radius: var(--radius-xl);
   }
 
+  .composer-sticky {
+    bottom: var(--spacing-2);
+    padding: var(--spacing-2) var(--spacing-3);
+    gap: var(--spacing-2);
+    border-radius: var(--radius-xl);
+  }
+
+  .composer-controls {
+    gap: var(--spacing-2);
+  }
+
   .canvas-title {
     font-size: 0.9rem;
   }
@@ -450,6 +501,15 @@
 
   .canvas-chip {
     padding: 4px 8px;
+  }
+
+  .mode-switch {
+    flex-wrap: wrap;
+  }
+
+  .mode-pill {
+    flex: 1;
+    text-align: center;
   }
 
   .messages-area-new {

--- a/src/components/ChatContainer.jsx
+++ b/src/components/ChatContainer.jsx
@@ -255,32 +255,6 @@ function ChatContainer() {
           <h2 className="canvas-title">Gemini 调试面板</h2>
           <p className="canvas-subtitle">Google AI Studio 风格的多模态对话体验</p>
         </div>
-        <div className="canvas-chips">
-          <span className="canvas-chip">
-            提供商 · {provider?.name}
-          </span>
-          <span className="canvas-chip">
-            模型 · {currentModel || provider?.defaultModel}
-          </span>
-          <span className={`canvas-chip ${settings.streamingEnabled ? 'chip-on' : 'chip-off'}`}>
-            流式 {settings.streamingEnabled ? '开启' : '关闭'}
-          </span>
-          <div className="mode-switch">
-            {[
-              { id: 'chat', label: '对话' },
-              { id: 'image', label: '图片' },
-              { id: 'video', label: '视频' }
-            ].map(mode => (
-              <button
-                key={mode.id}
-                className={`mode-pill ${generationMode === mode.id ? 'active' : ''}`}
-                onClick={() => setGenerationMode(mode.id)}
-              >
-                {mode.label}
-              </button>
-            ))}
-          </div>
-        </div>
       </div>
 
       {/* 消息区域 */}
@@ -365,9 +339,39 @@ function ChatContainer() {
         )}
       </div>
 
-      {/* 输入区域 */}
-      <div className="input-area-new">
-        <MultiModalInput onSend={handleSend} disabled={isLoading} mode={generationMode} />
+      {/* 控制与输入区域 */}
+      <div className="composer-sticky">
+        <div className="composer-controls">
+          <div className="canvas-chips">
+            <span className="canvas-chip">
+              提供商 · {provider?.name}
+            </span>
+            <span className="canvas-chip">
+              模型 · {currentModel || provider?.defaultModel}
+            </span>
+            <span className={`canvas-chip ${settings.streamingEnabled ? 'chip-on' : 'chip-off'}`}>
+              流式 {settings.streamingEnabled ? '开启' : '关闭'}
+            </span>
+          </div>
+          <div className="mode-switch">
+            {[
+              { id: 'chat', label: '对话' },
+              { id: 'image', label: '图片' },
+              { id: 'video', label: '视频' }
+            ].map(mode => (
+              <button
+                key={mode.id}
+                className={`mode-pill ${generationMode === mode.id ? 'active' : ''}`}
+                onClick={() => setGenerationMode(mode.id)}
+              >
+                {mode.label}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="input-area-new">
+          <MultiModalInput onSend={handleSend} disabled={isLoading} mode={generationMode} />
+        </div>
       </div>
 
       {/* 设置面板 */}


### PR DESCRIPTION
## Summary
- move provider, model, and streaming chips into a new sticky control row above the chat composer
- keep mode switch with the controls while simplifying the header spacing
- add responsive styling so the combined control and composer block stays near the bottom and stacks on small screens

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6930ec8c82fc832b9235f949d4f31bd5)