### PR TITLE
Improve mobile composer spacing and safe area handling

### DIFF
--- a/src/components/ChatContainer.css
+++ b/src/components/ChatContainer.css
@@ -304,6 +304,10 @@
 }
 
 /* 消息列表 */
+.chat-container-wrapper {
+  --composer-height: 0px;
+}
+
 .messages-list-new {
   padding: var(--spacing-6);
   display: flex;
@@ -313,6 +317,7 @@
   margin: 0 auto;
   width: 100%;
   position: relative;
+  padding-bottom: calc(var(--spacing-6) + var(--composer-height));
 }
 
 /* 自定义滚动条 */
@@ -337,7 +342,8 @@
 /* 输入区域 */
 .input-area-new {
   background: transparent;
-  padding: var(--spacing-4) var(--spacing-1) var(--spacing-1);
+  padding: var(--spacing-3) var(--spacing-1) var(--spacing-1);
+  padding-bottom: calc(var(--spacing-2) + env(safe-area-inset-bottom));
 }
 
 /* 响应式设计 */
@@ -426,7 +432,10 @@
   }
 
   .input-area-new {
-    padding: var(--spacing-3) 0 0;
+    position: sticky;
+    bottom: env(safe-area-inset-bottom);
+    padding: var(--spacing-2) var(--spacing-1) calc(var(--spacing-2) + env(safe-area-inset-bottom));
+    background: linear-gradient(180deg, transparent 0%, var(--bg-primary) 12%);
   }
 }
 
@@ -458,6 +467,7 @@
 
   .messages-list-new {
     padding: var(--spacing-3) var(--spacing-2);
+    padding-bottom: calc(var(--spacing-3) + var(--composer-height));
   }
 
   .feature-item {

--- a/src/components/ChatContainer.jsx
+++ b/src/components/ChatContainer.jsx
@@ -29,6 +29,8 @@ function ChatContainer() {
   const [editContent, setEditContent] = useState('')
   const [expandedGroups, setExpandedGroups] = useState({})
   const messagesEndRef = useRef(null)
+  const inputAreaRef = useRef(null)
+  const chatWrapperRef = useRef(null)
   const session = getCurrentSession()
   const provider = getCurrentProvider()
   const mergedApiKey = aiService.getApiKey(currentProvider)
@@ -55,6 +57,22 @@ function ChatContainer() {
   useEffect(() => {
     scrollToBottom()
   }, [session?.messages])
+
+  useEffect(() => {
+    const updateComposerHeight = () => {
+      const composerHeight = inputAreaRef.current?.offsetHeight || 0
+      if (chatWrapperRef.current) {
+        chatWrapperRef.current.style.setProperty('--composer-height', `${composerHeight}px`)
+      }
+    }
+
+    updateComposerHeight()
+    window.addEventListener('resize', updateComposerHeight)
+
+    return () => {
+      window.removeEventListener('resize', updateComposerHeight)
+    }
+  }, [session?.messages?.length, isLoading])
 
   // 切换分组展开状态
   const toggleGroupExpanded = (groupIndex) => {
@@ -248,7 +266,7 @@ function ChatContainer() {
   }
 
   return (
-    <div className="chat-container-wrapper">
+    <div className="chat-container-wrapper" ref={chatWrapperRef}>
       <div className="canvas-header">
         <div className="canvas-titles">
           <div className="eyebrow">Run</div>
@@ -366,7 +384,7 @@ function ChatContainer() {
       </div>
 
       {/* 输入区域 */}
-      <div className="input-area-new">
+      <div className="input-area-new" ref={inputAreaRef}>
         <MultiModalInput onSend={handleSend} disabled={isLoading} mode={generationMode} />
       </div>
 

--- a/src/components/MultiModalInput.css
+++ b/src/components/MultiModalInput.css
@@ -2,7 +2,7 @@
 .multimodal-input-container {
   position: relative;
   background: transparent;
-  padding: var(--spacing-6) var(--spacing-8);
+  padding: var(--spacing-4) var(--spacing-6);
   border-top: none;
   max-width: 960px;
   margin: 0 auto;
@@ -308,7 +308,10 @@
 /* 响应式 */
 @media (max-width: 768px) {
   .multimodal-input-container {
-    padding: var(--spacing-3) var(--spacing-2);
+    padding: var(--spacing-2) var(--spacing-2);
+    position: sticky;
+    bottom: calc(env(safe-area-inset-bottom) + var(--spacing-1));
+    z-index: 10;
   }
 
   .image-preview-area {
@@ -322,8 +325,8 @@
   }
 
   .input-wrapper {
-    padding: 8px 10px;
-    border-radius: 24px;
+    padding: 7px 9px;
+    border-radius: 22px;
   }
 
   .input-toolbar {
@@ -335,18 +338,18 @@
   }
 
   .upload-btn.icon {
-    width: 28px;
-    height: 28px;
+    width: 26px;
+    height: 26px;
   }
 
   .send-btn {
-    width: 36px;
-    height: 36px;
+    width: 34px;
+    height: 34px;
   }
 
   .message-textarea {
     font-size: var(--font-sm);
-    min-height: 32px;
+    min-height: 30px;
     padding: 6px 8px;
   }
 }
@@ -354,6 +357,7 @@
 @media (max-width: 480px) {
   .multimodal-input-container {
     padding: var(--spacing-2) var(--spacing-1);
+    bottom: calc(env(safe-area-inset-bottom) + var(--spacing-1));
   }
 
   .image-preview-item {
@@ -364,23 +368,23 @@
 
   .input-wrapper {
     padding: 6px 8px;
-    border-radius: 20px;
+    border-radius: 18px;
   }
 
   .upload-btn.icon {
-    width: 24px;
-    height: 24px;
+    width: 22px;
+    height: 22px;
   }
 
   .send-btn {
-    width: 32px;
-    height: 32px;
+    width: 30px;
+    height: 30px;
     margin-left: var(--spacing-1);
   }
 
   .message-textarea {
     font-size: 14px;
-    min-height: 28px;
+    min-height: 26px;
     padding: 4px 6px;
   }
 


### PR DESCRIPTION
## Summary
- make the chat composer sticky on mobile with safe-area padding and tighter spacing
- reduce multimodal input padding and control sizing for small screens
- add dynamic bottom padding to message lists based on composer height to prevent overlap

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6930ec91110c832b9ee6dbad5e0fbee2)