### PR TITLE
Refine message headers with avatars and badges

### DIFF
--- a/src/components/MessageRenderer.css
+++ b/src/components/MessageRenderer.css
@@ -39,14 +39,86 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: var(--spacing-3);
   padding-bottom: var(--spacing-2);
   border-bottom: 1px solid var(--border-primary);
 }
 
-.role-info {
+.message-header-left {
   display: flex;
   align-items: center;
   gap: var(--spacing-3);
+  min-width: 0;
+}
+
+.message-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 800;
+  font-size: var(--font-base);
+  border: 2px solid transparent;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
+}
+
+.avatar-symbol {
+  line-height: 1;
+}
+
+.message-avatar.user {
+  background: linear-gradient(135deg, #e0edff, #c8dcff);
+  color: #1d4ed8;
+  border-color: rgba(59, 130, 246, 0.35);
+}
+
+.message-avatar.assistant {
+  background: linear-gradient(135deg, #e5e7eb, #f4f4f5);
+  color: #7c3aed;
+  border-color: rgba(124, 58, 237, 0.35);
+}
+
+.message-author {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.author-name-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.author-name {
+  font-weight: 800;
+  font-size: var(--font-sm);
+  color: var(--text-primary);
+  letter-spacing: 0.01em;
+}
+
+.author-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: var(--radius-full);
+  background: rgba(124, 58, 237, 0.12);
+  color: #7c3aed;
+  font-weight: 700;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.author-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  color: var(--text-tertiary);
 }
 
 .role-label {
@@ -54,7 +126,7 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--text-secondary);
+  color: var(--text-tertiary);
 }
 
 .message-item.user .role-label {
@@ -66,6 +138,15 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
+}
+
+.streaming-status.compact {
+  gap: 6px;
+}
+
+.streaming-status.compact .streaming-dots span {
+  width: 5px;
+  height: 5px;
 }
 
 .streaming-dots {
@@ -111,6 +192,7 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
+  margin-left: auto;
 }
 
 .message-time {

--- a/src/components/MessageRenderer.jsx
+++ b/src/components/MessageRenderer.jsx
@@ -70,17 +70,17 @@ function MessageRenderer({
   const hasGeneratedImages = generatedImages.length > 0
 
   // 生成状态显示
-  const renderStreamingStatus = () => {
+  const renderStreamingStatus = (compact = false) => {
     if (!isStreaming) return null
 
     return (
-      <div className="streaming-status">
+      <div className={`streaming-status ${compact ? 'compact' : ''}`}>
         <div className="streaming-dots">
           <span></span>
           <span></span>
           <span></span>
         </div>
-        <span className="streaming-text">正在生成...</span>
+        {!compact && <span className="streaming-text">正在生成...</span>}
       </div>
     )
   }
@@ -89,9 +89,20 @@ function MessageRenderer({
     <div className={`message-item ${role} ${isError ? 'error' : ''} ${isStreaming ? 'streaming' : ''}`}>
       {/* 角色标签 */}
       <div className="message-role-header">
-        <div className="role-info">
-          <span className="role-label">{role === 'user' ? 'User' : 'Model'}</span>
-          {isStreaming && renderStreamingStatus()}
+        <div className="message-header-left">
+          <div className={`message-avatar ${role}`}>
+            <span className="avatar-symbol">{role === 'assistant' ? '✨' : '👤'}</span>
+          </div>
+          <div className="message-author">
+            <div className="author-name-row">
+              <span className="author-name">{role === 'user' ? 'User' : 'Wink AI'}</span>
+              {role === 'assistant' && <span className="author-badge">APP</span>}
+            </div>
+            <div className="author-meta">
+              <span className="role-label">{role === 'user' ? 'User' : 'Assistant'}</span>
+              {isStreaming && renderStreamingStatus(true)}
+            </div>
+          </div>
         </div>
         <div className="message-header-actions">
           <span className="message-time">


### PR DESCRIPTION
## Summary
- wrap message headers with avatar and author blocks including assistant APP badge and updated meta layout
- add compact streaming indicator variant for fitting generation status into header row
- refresh styling for avatars, badges, and header alignment while preserving existing actions

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69323d9ac36c832b9523e2210722dd14)